### PR TITLE
전체페이지에서 활동 누르면 상세페이지로 이동

### DIFF
--- a/src/ActivityPage.jsx
+++ b/src/ActivityPage.jsx
@@ -4,6 +4,8 @@ import { useSelector } from 'react-redux';
 
 import { Link, useParams } from 'react-router-dom';
 
+import resultData from './resultData';
+
 import { vitaminsImages } from './assets/images';
 
 import styled from '@emotion/styled';
@@ -47,11 +49,12 @@ const Item = styled.li({
 
 export default function ActivityPage() {
   const activityId = useParams();
-  const { text: { results } } = useSelector(get('result'));
-  const selectActivity = results.find((activity) => (
+
+  const selectActivity = resultData.map(({ text: { results } }) => (results.find((activity) => (
     Number(activityId.id) === Number(activity.activityId)
-  ));
-  const { text, detail, intro } = selectActivity;
+  ))));
+
+  const { text, detail, intro } = selectActivity[parseInt((activityId.id - 1) / 6)];
 
   return (
     <div>


### PR DESCRIPTION
**전체페이지에서 활동 누르면 상세페이지로 이동**

이전 로직에서 선택되어 state에 들어간 result 값만 받아와서 상세페이지를 보여줬기 때문에
전체페이지에서 result에 없는 활동을 누르면 오류가 발생했습니다
로직을 수정하여 전체 resultData를 받아오도록 했습니다

![image](https://user-images.githubusercontent.com/73640737/113692437-844b6c00-9708-11eb-97b9-3672a0ac0760.png)
